### PR TITLE
Allow Dropdowns to display more than 100 items

### DIFF
--- a/HillbillyCascade.js
+++ b/HillbillyCascade.js
@@ -76,7 +76,7 @@ $.fn.HillbillyCascade= function (optionsArray)
             url: _spPageContextInfo.webAbsoluteUrl + "/_api/Web/Lists/GetByTitle('"+params.childList+
                 "')/items?$select=Id,"+params.childLookupField+","+params.parentFieldInChildList+
                 "/Id&$expand="+params.parentFieldInChildList+"/Id&$filter="+params.parentFieldInChildList+
-                "/Id eq "+ parentID+"&$orderby=" + params.childLookupField+" &$top=9999",
+                "/Id eq "+ parentID+"&$orderby=" + params.childLookupField+" &$top="+params.dropDownItemCount,
             type: "GET",
             dataType: "json",
             headers: {

--- a/HillbillyCascade.js
+++ b/HillbillyCascade.js
@@ -76,7 +76,7 @@ $.fn.HillbillyCascade= function (optionsArray)
             url: _spPageContextInfo.webAbsoluteUrl + "/_api/Web/Lists/GetByTitle('"+params.childList+
                 "')/items?$select=Id,"+params.childLookupField+","+params.parentFieldInChildList+
                 "/Id&$expand="+params.parentFieldInChildList+"/Id&$filter="+params.parentFieldInChildList+
-                "/Id eq "+ parentID+"&$orderby=" + params.childLookupField,
+                "/Id eq "+ parentID+"&$orderby=" + params.childLookupField+" &$top=9999",
             type: "GET",
             dataType: "json",
             headers: {


### PR DESCRIPTION
Allow Dropdowns and Cascaded Dropdowns more than 100 items
by adding "&$top=9999" to the filter query, this enables to bypass the sharepoint  100 item limit for dropdowns